### PR TITLE
Ajout de Toulon/MTPM

### DIFF
--- a/main/citylist.json
+++ b/main/citylist.json
@@ -251,6 +251,12 @@
       "prod":true,
       "scope":"34_setethau"
    },
+   "Métropole Toulon Provence Méditerranée (beta)":{
+      "api_path":"https://vigilo.toulon-var-deplacements.fr",
+      "country":"France",
+      "prod":false,
+      "scope":"83_toulon"
+   },
    "Tours Métropole Val de Loire":{
       "api_path":"https://pp-mtp.vigilo.velocite-montpellier.fr",
       "country":"France",


### PR DESCRIPTION
Bonjour,

En tant qu'association Toulon Var Déplacements (TVD, toulon-var-deplacements.fr) on voudrait bien ajouter notre zone géographique.

Si j'ai bien compris tout ce-qu'il faut de notre côté (technique) c'est bien le serveur qui tourne déjà sous https://vigilo.toulon-var-deplacements.fr ?

Les docs sont un peu flou, je serais ravi d'y contribuer !

## Contact

contact@toulon-var-deplacements.fr

## Zone géographique

**Latitude:** N 43.01745 - 43.16362

**Longitude:** E 5.768852 - 6.184273

**Preview:** https://framacarte.org/en/map/vigilo-tvd_189628

![image](https://github.com/jesuisundesdeux/vigilo-conf/assets/189241/9cece5db-39ca-4454-a89e-fc056dbb88be)