### PR TITLE
chore: mettre toulon en prod

### DIFF
--- a/main/citylist.json
+++ b/main/citylist.json
@@ -251,10 +251,10 @@
       "prod":true,
       "scope":"34_setethau"
    },
-   "Métropole Toulon Provence Méditerranée (beta)":{
+   "Toulon Var":{
       "api_path":"https://vigilo.toulon-var-deplacements.fr",
       "country":"France",
-      "prod":false,
+      "prod":true,
       "scope":"83_toulon"
    },
    "Tours Métropole Val de Loire":{


### PR DESCRIPTION
Changement du nom aussi car la zone géographique comporte également des parties hors métropole.

On a testé avec des utilisateurs web, mais pour Android il n'y a pas de possibilité d'utiliser la beta si on est sur une version d'android trop récente, correct?

En tout cas, ça a l'air de marcher, merci bien pour cet outil! 😊 