### PR TITLE
Fix Laval Agglomeration api_path

### DIFF
--- a/main/citylist.json
+++ b/main/citylist.json
@@ -90,7 +90,7 @@
       "scope":"17_larochelle"
    },
    "Laval Agglomération":{
-     "api_path": "https://igilo.placeauvelo.org",
+      "api_path": "https://vigilo.placeauvelo.org",
       "country": "France",
       "prod": true,
       "scope": "53_laval"


### PR DESCRIPTION
Typo lors de l'inscription de l'instance Laval Agglomération dans `citylist.json`